### PR TITLE
Various msgp improvements

### DIFF
--- a/gen/marshal.go
+++ b/gen/marshal.go
@@ -10,18 +10,20 @@ import (
 	"github.com/algorand/msgp/msgp"
 )
 
-func marshal(w io.Writer) *marshalGen {
+func marshal(w io.Writer, topics *Topics) *marshalGen {
 	return &marshalGen{
-		p: printer{w: w},
+		p:      printer{w: w},
+		topics: topics,
 	}
 }
 
 type marshalGen struct {
 	passes
-	p    printer
-	fuse []byte
-	ctx  *Context
-	msgs []string
+	p      printer
+	fuse   []byte
+	ctx    *Context
+	msgs   []string
+	topics *Topics
 }
 
 func (m *marshalGen) Method() Method { return Marshal }
@@ -61,6 +63,9 @@ func (m *marshalGen) Execute(p Elem) ([]string, error) {
 		m.p.printf("\n  return ok")
 		m.p.printf("\n}")
 
+		m.topics.Add(methodRecv, "MarshalMsg")
+		m.topics.Add(methodRecv, "CanMarshalMsg")
+
 		return m.msgs, m.p.err
 	}
 
@@ -87,6 +92,9 @@ func (m *marshalGen) Execute(p Elem) ([]string, error) {
 
 	m.p.printf("\n  return ok")
 	m.p.printf("\n}")
+
+	m.topics.Add(methodRecv, "MarshalMsg")
+	m.topics.Add(methodRecv, "CanMarshalMsg")
 
 	return m.msgs, m.p.err
 }

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -91,22 +91,22 @@ type Printer struct {
 	gens []generator
 }
 
-func NewPrinter(m Method, out io.Writer, tests io.Writer) *Printer {
+func NewPrinter(m Method, topics *Topics, out io.Writer, tests io.Writer) *Printer {
 	if m.isset(Test) && tests == nil {
 		panic("cannot print tests with 'nil' tests argument!")
 	}
 	gens := make([]generator, 0, 7)
 	if m.isset(Marshal) {
-		gens = append(gens, marshal(out))
+		gens = append(gens, marshal(out, topics))
 	}
 	if m.isset(Unmarshal) {
-		gens = append(gens, unmarshal(out))
+		gens = append(gens, unmarshal(out, topics))
 	}
 	if m.isset(Size) {
-		gens = append(gens, sizes(out))
+		gens = append(gens, sizes(out, topics))
 	}
 	if m.isset(IsZero) {
-		gens = append(gens, isZeros(out))
+		gens = append(gens, isZeros(out, topics))
 	}
 	if m.isset(marshaltest) {
 		gens = append(gens, mtest(tests))

--- a/gen/topics.go
+++ b/gen/topics.go
@@ -1,0 +1,39 @@
+package gen
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+type Topics struct {
+	structs map[string][]string
+}
+
+func (t *Topics) Bytes() []byte {
+	outbuf := bytes.NewBuffer(make([]byte, 0, 4096))
+	outbuf.WriteString("// The following msgp objects are implemented in this file:\n")
+	for key, values := range t.structs {
+		outbuf.WriteString(fmt.Sprintf("// %s\n", key))
+		spaces := len(key) / 2
+		for _, value := range values {
+			outbuf.WriteString("// ")
+			outbuf.WriteString(strings.Repeat(" ", spaces))
+			outbuf.WriteString(fmt.Sprintf("|-----> %s\n", value))
+		}
+		outbuf.WriteString("//\n")
+	}
+	outbuf.WriteString("\n")
+	return outbuf.Bytes()
+}
+
+func (t *Topics) Add(key, value string) {
+	if t.structs == nil {
+		t.structs = make(map[string][]string)
+	}
+	if key[0] == '*' {
+		key = key[1:]
+		value = "(*) " + value
+	}
+	t.structs[key] = append(t.structs[key], value)
+}

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 )
 
-func unmarshal(w io.Writer) *unmarshalGen {
+func unmarshal(w io.Writer, topics *Topics) *unmarshalGen {
 	return &unmarshalGen{
-		p: printer{w: w},
+		p:      printer{w: w},
+		topics: topics,
 	}
 }
 
@@ -18,6 +19,7 @@ type unmarshalGen struct {
 	hasfield bool
 	ctx      *Context
 	msgs     []string
+	topics   *Topics
 }
 
 func (u *unmarshalGen) Method() Method { return Unmarshal }
@@ -62,6 +64,9 @@ func (u *unmarshalGen) Execute(p Elem) ([]string, error) {
 		u.p.printf("\n  return ok")
 		u.p.printf("\n}")
 
+		u.topics.Add(methodRecv, "UnmarshalMsg")
+		u.topics.Add(methodRecv, "CanUnmarshalMsg")
+
 		return u.msgs, u.p.err
 	}
 
@@ -78,6 +83,9 @@ func (u *unmarshalGen) Execute(p Elem) ([]string, error) {
 	u.p.printf("\n  _, ok := (%s).(%s)", c, methodRecv)
 	u.p.printf("\n  return ok")
 	u.p.printf("\n}")
+
+	u.topics.Add(methodRecv, "UnmarshalMsg")
+	u.topics.Add(methodRecv, "CanUnmarshalMsg")
 
 	return u.msgs, u.p.err
 }

--- a/issue185_test.go
+++ b/issue185_test.go
@@ -237,7 +237,7 @@ func goGenerateTpl(cwd, tfile string, tpl *template.Template, tplData interface{
 
 	mode := gen.Size | gen.Marshal | gen.Unmarshal
 
-	return Run(tfile, mode, false)
+	return Run(tfile, mode, false, "")
 }
 
 var issue185IdentsTpl = template.Must(template.New("").Parse(`

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -19,6 +19,7 @@ type FileSet struct {
 	PkgPath    string              // package path
 	Specs      map[string]ast.Expr // type specs in file
 	Aliases    map[string]ast.Expr // type aliases in file
+	Interfaces map[string]ast.Expr // type interfaces in file
 	Consts     map[string]ast.Expr // consts
 	Identities map[string]gen.Elem // processed from specs
 	Directives []string            // raw preprocessor directives
@@ -79,6 +80,7 @@ func packageToFileSet(p *packages.Package, imps map[string]*FileSet, unexported 
 		PkgPath:    p.PkgPath,
 		Specs:      make(map[string]ast.Expr),
 		Aliases:    make(map[string]ast.Expr),
+		Interfaces: make(map[string]ast.Expr),
 		Consts:     make(map[string]ast.Expr),
 		Identities: make(map[string]gen.Elem),
 		ImportSet:  imps,
@@ -356,6 +358,8 @@ func (fs *FileSet) getTypeSpecs(f *ast.File) {
 						} else {
 							fs.Aliases[s.Name.Name] = s.Type
 						}
+					case *ast.InterfaceType:
+						fs.Interfaces[s.Name.Name] = s.Type
 					}
 
 				case *ast.ValueSpec:
@@ -613,7 +617,8 @@ func (fs *FileSet) parseExpr(e ast.Expr) gen.Elem {
 		if b.Value == gen.IDENT {
 			_, specOK := fs.Specs[e.Name]
 			_, aliasOK := fs.Aliases[e.Name]
-			if !specOK && !aliasOK {
+			_, interfaceOK := fs.Interfaces[e.Name]
+			if !specOK && !aliasOK && !interfaceOK {
 				warnf("non-local identifier: %s\n", e.Name)
 			}
 		}


### PR DESCRIPTION
## Solution

This PR contains several changes -
1. On the header of the generated files, create a summary of which objects and function are implemented.
2. On each of the generated test files, a build tag was added. This buildtag could be used to exclude the build of the unit tests  ( needed for testing of encoding using non-test code )
3. Interfaces are now correctly detected, and would not generate warning during msgp execution. ( when running agains the go-algorand codebase, it would eliminate about half of the warning messages )

To illustrate what the gain of this PR are, take a look on https://github.com/algorand/go-algorand/pull/1125
( it would demonstrate #1 and #2; #3 is just the reduction of all the interface based `non-local identifier` warnings during build time )