### PR TITLE
Ensure topics are ordered

### DIFF
--- a/gen/topics.go
+++ b/gen/topics.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -13,7 +14,15 @@ type Topics struct {
 func (t *Topics) Bytes() []byte {
 	outbuf := bytes.NewBuffer(make([]byte, 0, 4096))
 	outbuf.WriteString("// The following msgp objects are implemented in this file:\n")
-	for key, values := range t.structs {
+
+	keys := []string{}
+	for key := range t.structs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		values := t.structs[key]
 		outbuf.WriteString(fmt.Sprintf("// %s\n", key))
 		spaces := len(key) / 2
 		for _, value := range values {


### PR DESCRIPTION
## Solution

Make sure the topics are ordered, so that two subsequent invocations would produce the same output.
( even if this is just a code-comment )

This change is required so that we could attempt to regenerate the msgp files and compare these against the branch files.