### PR TITLE
Add byte slice length check to the decoder

### DIFF
--- a/gen/spec.go
+++ b/gen/spec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 )
 
 const (
@@ -334,6 +335,7 @@ func (p *printer) resizeMap(size string, isnil string, m *Map, ctx string) []str
 	if allocbound == "" {
 		return []string{fmt.Sprintf("Missing allocbound on map %v", m)}
 	}
+	allocbound = strings.Split(allocbound, ",")[0]
 	if allocbound != "-" {
 		p.printf("\nif %s > %s {", size, allocbound)
 		p.printf("\nerr = msgp.ErrOverflow(uint64(%s), uint64(%s))", size, allocbound)
@@ -380,6 +382,7 @@ func (p *printer) resizeSlice(size string, isnil string, s *Slice, ctx string) [
 	if allocbound == "" {
 		return []string{fmt.Sprintf("Missing allocbound on slice %v", s)}
 	}
+	allocbound = strings.Split(allocbound, ",")[0]
 	if allocbound != "-" {
 		p.printf("\nif %s > %s {", size, allocbound)
 		p.printf("\nerr = msgp.ErrOverflow(uint64(%s), uint64(%s))", size, allocbound)

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -210,6 +210,16 @@ func (u *unmarshalGen) gBase(b *BaseElem) {
 
 	switch b.Value {
 	case Bytes:
+		if b.common.AllocBound() != "" {
+			sz := randIdent()
+			u.p.printf("\nvar %s int", sz)
+			u.p.printf("\n%s, err = msgp.ReadBytesBytesHeader(bts)", sz)
+			u.p.wrapErrCheck(u.ctx.ArgsStr())
+			u.p.printf("\nif %s > %s {", sz, b.common.AllocBound())
+			u.p.printf("\nerr = msgp.ErrOverflow(uint64(%s), %s)", sz, b.common.AllocBound())
+			u.p.printf("\nreturn")
+			u.p.printf("\n}")
+		}
 		u.p.printf("\n%s, bts, err = msgp.ReadBytesBytes(bts, %s)", refname, lowered)
 	case Ext:
 		u.p.printf("\nbts, err = msgp.ReadExtensionBytes(bts, %s)", lowered)

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"io"
 	"strconv"
+	"strings"
 )
 
 func unmarshal(w io.Writer, topics *Topics) *unmarshalGen {
@@ -278,7 +279,12 @@ func (u *unmarshalGen) gSlice(s *Slice) {
 	u.assignAndCheck(sz, isnil, arrayHeader)
 	resizemsgs := u.p.resizeSlice(sz, isnil, s, u.ctx.ArgsStr())
 	u.msgs = append(u.msgs, resizemsgs...)
-	u.p.rangeBlock(u.ctx, s.Index, s.Varname(), u, s.Els)
+	childElement := s.Els
+	if s.Els.AllocBound() == "" && len(strings.Split(s.AllocBound(), ",")) > 1 {
+		childElement = s.Els.Copy()
+		childElement.SetAllocBound(s.AllocBound()[strings.Index(s.AllocBound(), ",")+1:])
+	}
+	u.p.rangeBlock(u.ctx, s.Index, s.Varname(), u, childElement)
 }
 
 func (u *unmarshalGen) gMap(m *Map) {

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -406,6 +406,7 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 	sf := make([]gen.StructField, 1)
 	var extension, flatten bool
 	var allocbound string
+	var allocbounds []string
 
 	// always flatten embedded structs
 	flatten = true
@@ -420,7 +421,7 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 				extension = true
 			}
 			if strings.HasPrefix(tag, "allocbound=") {
-				allocbound = strings.Split(tag, "=")[1]
+				allocbounds = append(allocbounds, strings.Split(tag, "=")[1])
 			}
 		}
 		// ignore "-" fields
@@ -431,7 +432,7 @@ func (fs *FileSet) getField(f *ast.Field) []gen.StructField {
 		sf[0].FieldTagParts = tags
 		sf[0].RawTag = f.Tag.Value
 	}
-
+	allocbound = strings.Join(allocbounds, ",")
 	ex := fs.parseExpr(f.Type)
 	if ex == nil {
 		return nil


### PR DESCRIPTION
## Solution
Currently, we don't have a bounds on a byte slices in the msgp decoder. This change allows us to limit the size of a byte slice using the allocbound mechanism used for other slice/map types.

In terms of benefits, it allows to shifting (some) of the data structure validation into the decoder, ensuring that as long as the data structure metadata was defined correctly, we would have valid instances coming out of the decoder.

## Demo
see https://github.com/algorand/go-algorand/pull/1151
