### PR TITLE
Improve non-int bound checks

### DIFF
--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -217,7 +217,7 @@ func (u *unmarshalGen) gBase(b *BaseElem) {
 			u.p.printf("\n%s, err = msgp.ReadBytesBytesHeader(bts)", sz)
 			u.p.wrapErrCheck(u.ctx.ArgsStr())
 			u.p.printf("\nif %s > %s {", sz, b.common.AllocBound())
-			u.p.printf("\nerr = msgp.ErrOverflow(uint64(%s), %s)", sz, b.common.AllocBound())
+			u.p.printf("\nerr = msgp.ErrOverflow(uint64(%s), uint64(%s))", sz, b.common.AllocBound())
 			u.p.printf("\nreturn")
 			u.p.printf("\n}")
 		}


### PR DESCRIPTION
## Issue

When specifying size using
Note        []byte            `codec:"note,allocbound=config.MaxTxnNoteBytes"`

The `config.MaxTxnNoteBytes` is expected to be of type int. This is a limitation that isn't really needed. Any integer-type would do, as we don't typically want to check anything beyond 32-bit anyway.

## Solution
This change convert the expected size value passed to ErrOverflow to uint64, allowing to restict array sizes to non-int sizes as well. ( i.e. uint64 or int64 are good examples. But also int8 or int16 )