### PR TITLE
properly handle embedded structs from another package

### DIFF
--- a/gen/elem.go
+++ b/gen/elem.go
@@ -226,11 +226,12 @@ type Elem interface {
 
 // Ident returns the *BaseElem that corresponds
 // to the provided identity.
-func Ident(id string) *BaseElem {
+func Ident(importPrefix string, id string) *BaseElem {
 	p, ok := primitives[id]
 	if ok {
 		return &BaseElem{Value: p}
 	}
+	id = importPrefix + id
 	be := &BaseElem{Value: IDENT, IdentName: id}
 	be.Alias(id)
 	return be

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -62,7 +62,7 @@ func applyShim(text []string, f *FileSet) error {
 	}
 
 	name := text[1]
-	be := gen.Ident(strings.TrimPrefix(strings.TrimSpace(text[2]), "as:")) // parse as::{base}
+	be := gen.Ident("", strings.TrimPrefix(strings.TrimSpace(text[2]), "as:")) // parse as::{base}
 	if name[0] == '*' {
 		name = name[1:]
 		be.Needsref(true)


### PR DESCRIPTION
If an embedded struct comes from another package, and it has fields
referring to identifiers in that other package, this change makes the
generated code correctly refer to those identifiers using the name of
the imported package.

This turns out to be needed for go-algorand PR #1856, since the agreement
package has an embedded field of type bookkeeping.BlockHeader, which in
turn now has a field of type map[...]CompactCertState.  The generated msgp
code needs to refer to the map elements as bookkeeping.CompactCertState.