### PR TITLE
Add partitioning to generated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ msgp/defgen_test.go
 msgp/cover.out
 *~
 *.coverprofile
+.idea/

--- a/gen/testgen.go
+++ b/gen/testgen.go
@@ -61,7 +61,6 @@ func init() {
 }
 
 func TestRandomizedEncoding{{.TypeName}}(t *testing.T) {
-	partitiontest.PartitionTest(t)
 	protocol.RunEncodingTest(t, &{{.TypeName}}{})
 }
 

--- a/gen/testgen.go
+++ b/gen/testgen.go
@@ -40,6 +40,7 @@ func (m *mtestGen) Method() Method { return marshaltest }
 
 func init() {
 	template.Must(marshalTestTempl.Parse(`func TestMarshalUnmarshal{{.TypeName}}(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	v := {{.TypeName}}{}
 	bts := v.MarshalMsg(nil)
 	left, err := v.UnmarshalMsg(bts)
@@ -60,6 +61,7 @@ func init() {
 }
 
 func TestRandomizedEncoding{{.TypeName}}(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	protocol.RunEncodingTest(t, &{{.TypeName}}{})
 }
 

--- a/printer/print.go
+++ b/printer/print.go
@@ -105,7 +105,9 @@ func generate(f *parse.FileSet, mode gen.Method) (*bytes.Buffer, *bytes.Buffer, 
 		testbuf = bytes.NewBuffer(make([]byte, 0, 4096))
 		writeBuildHeader(testbuf, []string{"!skip_msgp_testing"})
 		writePkgHeader(testbuf, f.Package)
-		writeImportHeader(testbuf, "github.com/algorand/msgp/msgp", "testing")
+		writeImportHeader(
+			testbuf,
+			"github.com/algorand/msgp/msgp", "github.com/algorand/go-algorand/test/partitiontest", "testing")
 		testwr = testbuf
 	}
 	funcbuf := bytes.NewBuffer(make([]byte, 0, 4096))


### PR DESCRIPTION
This adds the partitiontest import and the two partition test calls needed in the generated test code. I tested this by building a new msgp, running `make msgp` locally, checking that the lines were added correctly and running `make shorttest`. 