### PR TITLE
Add missing partitioning to generated tests.

### DIFF
--- a/gen/testgen.go
+++ b/gen/testgen.go
@@ -61,6 +61,7 @@ func init() {
 }
 
 func TestRandomizedEncoding{{.TypeName}}(t *testing.T) {
+	partitiontest.PartitionTest(t)
 	protocol.RunEncodingTest(t, &{{.TypeName}}{})
 }
 


### PR DESCRIPTION
The partition was only added to one of the two test functions.