### PR TITLE
Golang 1.17 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ msgp/cover.out
 *~
 *.coverprofile
 .idea/
+cover.out

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@
 # Installation can still be performed with a
 # normal `go install`.
 
-# generated integration test files
-GGEN = ./_generated/generated.go ./_generated/generated_test.go
 # generated unit test files
 MGEN = ./msgp/defgen_test.go
 
@@ -20,20 +18,17 @@ $(BIN): */*.go
 
 install: $(BIN)
 
-$(GGEN): ./_generated/def.go
-	go generate ./_generated
-
 $(MGEN): ./msgp/defs_test.go
 	go generate ./msgp
 
 test: all
-	go test ./... ./_generated
+	go test -covermode=atomic -coverprofile=cover.out ./...
 
 bench: all
 	go test -bench ./...
 
 clean:
-	$(RM) $(GGEN) $(MGEN)
+	$(RM) $(MGEN)
 
 wipe: clean
 	$(RM) $(BIN)
@@ -41,7 +36,7 @@ wipe: clean
 get-deps:
 	go get -d -t ./...
 
-all: install $(GGEN) $(MGEN)
+all: install $(MGEN)
 
 # travis CI enters here
 travis:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,13 @@
 module github.com/algorand/msgp
 
-go 1.16
+go 1.17
 
 require (
 	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31
 	golang.org/x/tools v0.0.0-20200423205358-59e73619c742
+)
+
+require (
+	golang.org/x/mod v0.2.0 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 )

--- a/printer/print.go
+++ b/printer/print.go
@@ -145,6 +145,6 @@ func writeImportHeader(b *bytes.Buffer, imports ...string) {
 }
 
 func writeBuildHeader(b *bytes.Buffer, buildHeaders []string) {
-	headers := fmt.Sprintf("//go:build %s\n\n", strings.Join(buildHeaders, " "))
+	headers := fmt.Sprintf("//go:build %s\n// +build %s\n\n", strings.Join(buildHeaders, " "), strings.Join(buildHeaders, " "))
 	b.WriteString(headers)
 }

--- a/printer/print.go
+++ b/printer/print.go
@@ -145,6 +145,6 @@ func writeImportHeader(b *bytes.Buffer, imports ...string) {
 }
 
 func writeBuildHeader(b *bytes.Buffer, buildHeaders []string) {
-	headers := fmt.Sprintf("// +build %s\n\n", strings.Join(buildHeaders, " "))
+	headers := fmt.Sprintf("//go:build %s\n\n", strings.Join(buildHeaders, " "))
 	b.WriteString(headers)
 }

--- a/printer/print_test.go
+++ b/printer/print_test.go
@@ -9,7 +9,7 @@ func TestWriteBuildHeader(t *testing.T) {
 	testBuf := bytes.NewBuffer(make([]byte, 0, 4096))
 	buildHeaders := []string{"foobar"}
 	expectedBuf := bytes.NewBuffer(make([]byte, 0, 4096))
-	expectedBuf.WriteString("//go:build foobar\n\n")
+	expectedBuf.WriteString("//go:build foobar\n// +build foobar\n\n")
 
 	writeBuildHeader(testBuf, buildHeaders)
 

--- a/printer/print_test.go
+++ b/printer/print_test.go
@@ -1,0 +1,19 @@
+package printer
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteBuildHeader(t *testing.T) {
+	testBuf := bytes.NewBuffer(make([]byte, 0, 4096))
+	buildHeaders := []string{"foobar"}
+	expectedBuf := bytes.NewBuffer(make([]byte, 0, 4096))
+	expectedBuf.WriteString("//go:build foobar\n\n")
+
+	writeBuildHeader(testBuf, buildHeaders)
+
+	if testBuf.String() != expectedBuf.String() {
+		t.Errorf("testBuf:\n%s not equal to expectedBuf:\n%s", testBuf, expectedBuf)
+	}
+}


### PR DESCRIPTION
Migrate writing build headers from `//+build` to `//go:build`.

This change was made in go1.17 which means it will be backwards incompatible with anything older than that. I have go upgrades for all of go-sdk, go-algorand, and indexer in PR so that shouldn't be a problem.

I also removed all of the _generated tests from the Makefile since they cause `make test` to fail.  
Additionally, I've added coverage output and a unit test for the function I've updated which is currently uncovered (possibly because the _generated tests no longer work.