### PR TITLE
Add missing protocol package import

### DIFF
--- a/printer/print.go
+++ b/printer/print.go
@@ -122,7 +122,10 @@ func generate(f *parse.FileSet, mode gen.Method) (*bytes.Buffer, *bytes.Buffer, 
 		writePkgHeader(testbuf, f.Package)
 		writeImportHeader(
 			testbuf,
-			"github.com/algorand/msgp/msgp", "github.com/algorand/go-algorand/test/partitiontest", "testing")
+			"github.com/algorand/msgp/msgp",
+			"github.com/algorand/go-algorand/protocol",
+			"github.com/algorand/go-algorand/test/partitiontest",
+			"testing")
 		testwr = testbuf
 	}
 	funcbuf := bytes.NewBuffer(make([]byte, 0, 4096))


### PR DESCRIPTION
This seems to have been working for a while (since e82843c6b8acc337c62bddd3a0cec1fc49e6a63d) without this import, but when running the msgp generator in CircleCI (in algorand/go-algorand#3978) it doesn't seem to detect that the protocol package needs to be added to generated test files.