### PR TITLE
Add support for encoding time.Duration

### DIFF
--- a/gen/elem.go
+++ b/gen/elem.go
@@ -91,10 +91,11 @@ const (
 	Int32
 	Int64
 	Bool
-	Intf  // interface{}
-	Time  // time.Time
-	Ext   // extension
-	Error // error
+	Intf     // interface{}
+	Time     // time.Time
+	Ext      // extension
+	Error    // error
+	Duration // time.Duration
 
 	IDENT // IDENT means an unrecognized identifier
 )
@@ -126,6 +127,7 @@ var primitives = map[string]Primitive{
 	"time.Time":      Time,
 	"msgp.Extension": Ext,
 	"error":          Error,
+	"time.Duration":  Duration,
 }
 
 // types built into the library
@@ -757,10 +759,13 @@ func (s *BaseElem) FromBase() string {
 // BaseName returns the string form of the
 // base type (e.g. Float64, Ident, etc)
 func (s *BaseElem) BaseName() string {
-	// time is a special case;
+	// time and duration are special cases;
 	// we strip the package prefix
 	if s.Value == Time {
 		return "Time"
+	}
+	if s.Value == Duration {
+		return "Duration"
 	}
 	return s.Value.String()
 }
@@ -841,7 +846,8 @@ func (s *BaseElem) ZeroExpr() string {
 		Int8,
 		Int16,
 		Int32,
-		Int64:
+		Int64,
+		Duration:
 		return "0"
 	case Bool:
 		return "false"
@@ -933,6 +939,8 @@ func (k Primitive) String() string {
 		return "Intf"
 	case Time:
 		return "time.Time"
+	case Duration:
+		return "time.Duration"
 	case Ext:
 		return "Extension"
 	case IDENT:

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -387,6 +387,16 @@ func ReadBoolBytes(b []byte) (bool, []byte, error) {
 	}
 }
 
+// ReadDurationBytes tries to read a time.Duration
+// from 'b' and return the value and the remaining bytes.
+// Possible errors:
+// - ErrShortBytes (too few bytes)
+// - TypeError (not a int)
+func ReadDurationBytes(b []byte) (d time.Duration, o []byte, err error) {
+	i, o, err := ReadInt64Bytes(b)
+	return time.Duration(i), o, err
+}
+
 // ReadInt64Bytes tries to read an int64
 // from 'b' and return the value and the remaining bytes.
 // Possible errors:

--- a/msgp/size.go
+++ b/msgp/size.go
@@ -25,9 +25,10 @@ const (
 	Complex64Size  = 10
 	Complex128Size = 18
 
-	TimeSize = 15
-	BoolSize = 1
-	NilSize  = 1
+	DurationSize = Int64Size
+	TimeSize     = 15
+	BoolSize     = 1
+	NilSize      = 1
 
 	MapHeaderSize   = 5
 	ArrayHeaderSize = 5

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -75,6 +75,11 @@ func AppendFloat32(b []byte, f float32) []byte {
 	return o
 }
 
+// AppendDuration appends a time.Duration to the slice
+func AppendDuration(b []byte, d time.Duration) []byte {
+	return AppendInt64(b, int64(d))
+}
+
 // AppendInt64 appends an int64 to the slice
 func AppendInt64(b []byte, i int64) []byte {
 	if i >= 0 {


### PR DESCRIPTION
Support for `time.Duration` is necessary in order to serialize agreement crash state using msgp instead of reflect for https://github.com/algorand/go-algorand/issues/4550 

These changes are manually cherry-picked changes from the upstream tinylib repo commits listed below. They were done manually because our repos have diverged enough that real cherry-picks were introducing a lot of conflicts. They are merged into `master` but not yet included in a tagged release. 

[77976d5b6d9c014b96d4be0b169d0c4dc9ac1a0b](https://github.com/tinylib/msgp/commit/77976d5b6d9c014b96d4be0b169d0c4dc9ac1a0b)
[5467d2f6f6238b93ec0a064bada8dcf9f081e603](https://github.com/tinylib/msgp/commit/5467d2f6f6238b93ec0a064bada8dcf9f081e603) 
[618077c9521bd18d4c5b22dcb45444c2d8ffa3e9](https://github.com/tinylib/msgp/commit/618077c9521bd18d4c5b22dcb45444c2d8ffa3e9)
[66ba8975dc3b0a050050e60694dd446a7e64431c](https://github.com/tinylib/msgp/commit/66ba8975dc3b0a050050e60694dd446a7e64431c)
[fd0c04e0f5ca1995ec6b166faa8f2f30ec0b1c99](https://github.com/tinylib/msgp/commit/fd0c04e0f5ca1995ec6b166faa8f2f30ec0b1c99)
[222902d7cb87b1061282d75abec3327692e549e8](https://github.com/tinylib/msgp/commit/222902d7cb87b1061282d75abec3327692e549e8)