### PR TITLE
Add ...MaxSize() functions, totalallocbound annotations and string allocbounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ msgp/cover.out
 *~
 *.coverprofile
 .idea/
+.vscode/
 cover.out

--- a/gen/elem.go
+++ b/gen/elem.go
@@ -155,20 +155,23 @@ func (c Callback) GetName() string            { return c.Fname }
 
 // common data/methods for every Elem
 type common struct {
-	vname, alias string
-	allocbound   string
-	callbacks    []Callback
+	vname, alias  string
+	allocbound    string
+	maxtotalbytes string
+	callbacks     []Callback
 }
 
-func (c *common) SetVarname(s string)      { c.vname = s }
-func (c *common) Varname() string          { return c.vname }
-func (c *common) Alias(typ string)         { c.alias = typ }
-func (c *common) SortInterface() string    { return "" }
-func (c *common) SetAllocBound(s string)   { c.allocbound = s }
-func (c *common) AllocBound() string       { return c.allocbound }
-func (c *common) GetCallbacks() []Callback { return c.callbacks }
-func (c *common) AddCallback(cb Callback)  { c.callbacks = append(c.callbacks, cb) }
-func (c *common) hidden()                  {}
+func (c *common) SetVarname(s string)       { c.vname = s }
+func (c *common) Varname() string           { return c.vname }
+func (c *common) Alias(typ string)          { c.alias = typ }
+func (c *common) SortInterface() string     { return "" }
+func (c *common) SetAllocBound(s string)    { c.allocbound = s }
+func (c *common) AllocBound() string        { return c.allocbound }
+func (c *common) SetMaxTotalBytes(s string) { c.maxtotalbytes = s }
+func (c *common) MaxTotalBytes() string     { return c.maxtotalbytes }
+func (c *common) GetCallbacks() []Callback  { return c.callbacks }
+func (c *common) AddCallback(cb Callback)   { c.callbacks = append(c.callbacks, cb) }
+func (c *common) hidden()                   {}
 
 func IsDangling(e Elem) bool {
 	if be, ok := e.(*BaseElem); ok && be.Dangling() {
@@ -240,6 +243,15 @@ type Elem interface {
 	// AllocBound returns the maximum number of elements to allocate
 	// when decoding this type.  Meaningful for slices and maps.
 	AllocBound() string
+
+	// SetMaxTotalBytes specifies the maximum number of bytes to allocate when
+	// decoding this type.
+	// Blank means unspecified bound.  "-" means no bound.
+	SetMaxTotalBytes(bound string)
+
+	// MaxTotalBytes specifies the maximum number of bytes to allocate when
+	// decoding this type. Meaningful for slices of strings or byteslices.
+	MaxTotalBytes() string
 
 	// AddCallback adds to the elem a Callback it should call at the end of marshaling
 	AddCallback(Callback)

--- a/gen/maxsize.go
+++ b/gen/maxsize.go
@@ -1,0 +1,325 @@
+package gen
+
+import (
+	"fmt"
+	"go/ast"
+	"io"
+	"strconv"
+
+	"github.com/algorand/msgp/msgp"
+)
+
+type sizeState uint8
+
+const (
+	// need to write "s = ..."
+	assign sizeState = iota
+
+	// need to write "s += ..."
+	add
+
+	// can just append "+ ..."
+	expr
+)
+
+func sizes(w io.Writer, topics *Topics) *sizeGen {
+	return &sizeGen{
+		p:      printer{w: w},
+		state:  assign,
+		topics: topics,
+	}
+}
+
+type sizeGen struct {
+	passes
+	p      printer
+	state  sizeState
+	ctx    *Context
+	topics *Topics
+}
+
+func (s *sizeGen) Method() Method { return Size }
+
+func (s *sizeGen) Apply(dirs []string) error {
+	return nil
+}
+
+func builtinSize(typ string) string {
+	return "msgp." + typ + "Size"
+}
+
+// this lets us chain together addition
+// operations where possible
+func (s *sizeGen) addConstant(sz string) {
+	if !s.p.ok() {
+		return
+	}
+
+	switch s.state {
+	case assign:
+		s.p.print("\ns = " + sz)
+		s.state = expr
+		return
+	case add:
+		s.p.print("\ns += " + sz)
+		s.state = expr
+		return
+	case expr:
+		s.p.print(" + " + sz)
+		return
+	}
+
+	panic("unknown size state")
+}
+
+func (s *sizeGen) Execute(p Elem) ([]string, error) {
+	if !s.p.ok() {
+		return nil, s.p.err
+	}
+	p = s.applyall(p)
+	if p == nil {
+		return nil, nil
+	}
+
+	// We might change p.Varname in methodReceiver(); make a copy
+	// to not affect other code that will use p.
+	p = p.Copy()
+
+	s.p.comment("Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message")
+
+	if IsDangling(p) {
+		baseType := p.(*BaseElem).IdentName
+		ptrName := p.Varname()
+		receiver := methodReceiver(p)
+		s.p.printf("\nfunc (%s %s) Msgsize() int {", ptrName, receiver)
+		s.p.printf("\n  return ((*(%s))(%s)).Msgsize()", baseType, ptrName)
+		s.p.printf("\n}")
+		s.topics.Add(receiver, "Msgsize")
+		return nil, s.p.err
+	}
+
+	s.ctx = &Context{}
+	s.ctx.PushString(p.TypeName())
+
+	ptrName := p.Varname()
+	receiver := imutMethodReceiver(p)
+	s.p.printf("\nfunc (%s %s) Msgsize() (s int) {", ptrName, receiver)
+	s.state = assign
+	next(s, p)
+	s.p.nakedReturn()
+	s.topics.Add(receiver, "Msgsize")
+	return nil, s.p.err
+}
+
+func (s *sizeGen) gStruct(st *Struct) {
+	if !s.p.ok() {
+		return
+	}
+
+	nfields := uint32(0)
+	for i := range st.Fields {
+		if ast.IsExported(st.Fields[i].FieldName) {
+			nfields += 1
+		}
+	}
+
+	if st.AsTuple {
+		data := msgp.AppendArrayHeader(nil, nfields)
+		s.addConstant(strconv.Itoa(len(data)))
+		for i := range st.Fields {
+			if !ast.IsExported(st.Fields[i].FieldName) {
+				continue
+			}
+
+			if !s.p.ok() {
+				return
+			}
+			next(s, st.Fields[i].FieldElem)
+		}
+	} else {
+		data := msgp.AppendMapHeader(nil, nfields)
+		s.addConstant(strconv.Itoa(len(data)))
+		for i := range st.Fields {
+			if !ast.IsExported(st.Fields[i].FieldName) {
+				continue
+			}
+
+			data = data[:0]
+			data = msgp.AppendString(data, st.Fields[i].FieldTag)
+			s.addConstant(strconv.Itoa(len(data)))
+			next(s, st.Fields[i].FieldElem)
+		}
+	}
+}
+
+func (s *sizeGen) gPtr(p *Ptr) {
+	s.state = add // inner must use add
+	s.p.printf("\nif %s == nil {\ns += msgp.NilSize\n} else {", p.Varname())
+	next(s, p.Value)
+	s.state = add // closing block; reset to add
+	s.p.closeblock()
+}
+
+func (s *sizeGen) gSlice(sl *Slice) {
+	if !s.p.ok() {
+		return
+	}
+
+	s.addConstant(builtinSize(arrayHeader))
+
+	// if the slice's element is a fixed size
+	// (e.g. float64, [32]int, etc.), then
+	// print the length times the element size directly
+	if str, ok := fixedsizeExpr(sl.Els); ok {
+		s.addConstant(fmt.Sprintf("(%s * (%s))", lenExpr(sl), str))
+		return
+	}
+
+	// add inside the range block, and immediately after
+	s.state = add
+	s.p.rangeBlock(s.ctx, sl.Index, sl.Varname(), s, sl.Els)
+	s.state = add
+}
+
+func (s *sizeGen) gArray(a *Array) {
+	if !s.p.ok() {
+		return
+	}
+
+	s.addConstant(builtinSize(arrayHeader))
+
+	// if the array's children are a fixed
+	// size, we can compile an expression
+	// that always represents the array's wire size
+	if str, ok := fixedsizeExpr(a); ok {
+		s.addConstant(str)
+		return
+	}
+
+	s.state = add
+	s.p.rangeBlock(s.ctx, a.Index, a.Varname(), s, a.Els)
+	s.state = add
+}
+
+func (s *sizeGen) gMap(m *Map) {
+	s.addConstant(builtinSize(mapHeader))
+	vn := m.Varname()
+	s.p.printf("\nif %s != nil {", vn)
+	s.p.printf("\nfor %s, %s := range %s {", m.Keyidx, m.Validx, vn)
+	s.p.printf("\n_ = %s", m.Keyidx) // we may not use the key
+	s.p.printf("\n_ = %s", m.Validx) // we may not use the value
+	s.p.printf("\ns += 0")
+	s.state = expr
+	s.ctx.PushVar(m.Keyidx)
+	next(s, m.Key)
+	next(s, m.Value)
+	s.ctx.Pop()
+	s.p.closeblock()
+	s.p.closeblock()
+	s.state = add
+}
+
+func (s *sizeGen) gBase(b *BaseElem) {
+	if !s.p.ok() {
+		return
+	}
+	if b.Convert && b.ShimMode == Convert {
+		s.state = add
+		vname := randIdent()
+		s.p.printf("\nvar %s %s", vname, b.BaseType())
+
+		// ensure we don't get "unused variable" warnings from outer slice iterations
+		s.p.printf("\n_ = %s", b.Varname())
+
+		s.p.printf("\ns += %s", basesizeExpr(b.Value, vname, b.BaseName()))
+		s.state = expr
+
+	} else {
+		vname := b.Varname()
+		if b.Convert {
+			vname = tobaseConvert(b)
+		}
+		s.addConstant(basesizeExpr(b.Value, vname, b.BaseName()))
+	}
+}
+
+// returns "len(slice)"
+func lenExpr(sl *Slice) string {
+	return "len(" + sl.Varname() + ")"
+}
+
+// is a given primitive always the same (max)
+// size on the wire?
+func fixedSize(p Primitive) bool {
+	switch p {
+	case Intf, Ext, IDENT, Bytes, String:
+		return false
+	default:
+		return true
+	}
+}
+
+// strip reference from string
+func stripRef(s string) string {
+	if s[0] == '&' {
+		return s[1:]
+	}
+	return s
+}
+
+// return a fixed-size expression, if possible.
+// only possible for *BaseElem and *Array.
+// returns (expr, ok)
+func fixedsizeExpr(e Elem) (string, bool) {
+	switch e := e.(type) {
+	case *Array:
+		if str, ok := fixedsizeExpr(e.Els); ok {
+			return fmt.Sprintf("(%s * (%s))", e.Size, str), true
+		}
+	case *BaseElem:
+		if fixedSize(e.Value) {
+			return builtinSize(e.BaseName()), true
+		}
+	case *Struct:
+		var str string
+		for _, f := range e.Fields {
+			if fs, ok := fixedsizeExpr(f.FieldElem); ok {
+				if str == "" {
+					str = fs
+				} else {
+					str += "+" + fs
+				}
+			} else {
+				return "", false
+			}
+		}
+		var hdrlen int
+		mhdr := msgp.AppendMapHeader(nil, uint32(len(e.Fields)))
+		hdrlen += len(mhdr)
+		var strbody []byte
+		for _, f := range e.Fields {
+			strbody = msgp.AppendString(strbody[:0], f.FieldTag)
+			hdrlen += len(strbody)
+		}
+		return fmt.Sprintf("%d + %s", hdrlen, str), true
+	}
+	return "", false
+}
+
+// print size expression of a variable name
+func basesizeExpr(value Primitive, vname, basename string) string {
+	switch value {
+	case Ext:
+		return "msgp.ExtensionPrefixSize + " + stripRef(vname) + ".Len()"
+	case Intf:
+		return "msgp.GuessSize(" + vname + ")"
+	case IDENT:
+		return vname + ".Msgsize()"
+	case Bytes:
+		return "msgp.BytesPrefixSize + len(" + vname + ")"
+	case String:
+		return "msgp.StringPrefixSize + len(" + vname + ")"
+	default:
+		return builtinSize(basename)
+	}
+}

--- a/gen/spec.go
+++ b/gen/spec.go
@@ -39,11 +39,13 @@ func (m Method) String() string {
 		return "size"
 	case IsZero:
 		return "iszero"
+	case MaxSize:
+		return "maxsize"
 	case Test:
 		return "test"
 	default:
 		// return e.g. "marshal+unmarshal+test"
-		modes := [...]Method{Marshal, Unmarshal, Size, IsZero, Test}
+		modes := [...]Method{Marshal, Unmarshal, Size, IsZero, MaxSize, Test}
 		any := false
 		nm := ""
 		for _, mm := range modes {
@@ -71,6 +73,8 @@ func strtoMeth(s string) Method {
 		return Size
 	case "iszero":
 		return IsZero
+	case "maxsize":
+		return MaxSize
 	case "test":
 		return Test
 	default:
@@ -84,6 +88,7 @@ const (
 	Size                                                 // msgp.Sizer
 	IsZero                                               // implement MsgIsZero()
 	Test                                                 // generate tests
+	MaxSize                                              // msgp.MaxSize
 	invalidmeth                                          // this isn't a method
 	marshaltest = Marshal | Unmarshal | Test             // tests for Marshaler and Unmarshaler
 )
@@ -108,6 +113,9 @@ func NewPrinter(m Method, topics *Topics, out io.Writer, tests io.Writer) *Print
 	}
 	if m.isset(IsZero) {
 		gens = append(gens, isZeros(out, topics))
+	}
+	if m.isset(MaxSize) {
+		gens = append(gens, maxSizes(out, topics))
 	}
 	if m.isset(marshaltest) {
 		gens = append(gens, mtest(tests))

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -237,6 +237,18 @@ func (u *unmarshalGen) gBase(b *BaseElem) {
 		u.p.printf("\nbts, err = msgp.ReadExtensionBytes(bts, %s)", lowered)
 	case IDENT:
 		u.p.printf("\nbts, err = %s.UnmarshalMsg(bts)", lowered)
+	case String:
+		if b.common.AllocBound() != "" {
+			sz := randIdent()
+			u.p.printf("\nvar %s int", sz)
+			u.p.printf("\n%s, err = msgp.ReadBytesBytesHeader(bts)", sz)
+			u.p.wrapErrCheck(u.ctx.ArgsStr())
+			u.p.printf("\nif %s > %s {", sz, b.common.AllocBound())
+			u.p.printf("\nerr = msgp.ErrOverflow(uint64(%s), uint64(%s))", sz, b.common.AllocBound())
+			u.p.printf("\nreturn")
+			u.p.printf("\n}")
+		}
+		u.p.printf("\n%s, bts, err = msgp.ReadStringBytes(bts)", refname)
 	default:
 		u.p.printf("\n%s, bts, err = msgp.Read%sBytes(bts)", refname, b.BaseName())
 	}

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	var mode gen.Method
 	if *marshal {
-		mode |= (gen.Marshal | gen.Unmarshal | gen.Size | gen.IsZero)
+		mode |= (gen.Marshal | gen.Unmarshal | gen.Size | gen.IsZero | gen.MaxSize)
 	}
 	if *tests {
 		mode |= gen.Test

--- a/msgp/write.go
+++ b/msgp/write.go
@@ -11,6 +11,16 @@ type Sizer interface {
 	Msgsize() int
 }
 
+// MaxSizer is an interface implemented
+// by types that can determine their max
+// when implemented.
+// This interface is optional, but
+// implementations may use this as a way to limit
+// number of bytes read during deserialization
+type MaxSizer interface {
+	MaxSize() int
+}
+
 // Require ensures that cap(old)-len(old) >= extra.
 // It might be that this is impossible because len(old)+extra
 // overflows int.  If so, Require will not grow the slice,

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -27,7 +27,7 @@ var directives = map[string]directive{
 	"tuple":      astuple,
 	"sort":       sortintf,
 	"allocbound": allocbound,
-	// _postunmarshalcheck is used to add callbacks to the end of unmarshling that are tied to a specific Element.
+	// _postunmarshalcheck is used to add callbacks to the end of un-marshalling that are tied to a specific Element.
 	_postunmarshalcheck: postunmarshalcheck,
 }
 

--- a/parse/getast.go
+++ b/parse/getast.go
@@ -167,10 +167,10 @@ func (f *FileSet) applyDirectives() {
 // into just one level of indirection.
 // In other words, if we have:
 //
-//  type A uint64
-//  type B A
-//  type C B
-//  type D C
+//	type A uint64
+//	type B A
+//	type C B
+//	type D C
 //
 // ... then we want to end up
 // figuring out that D is just a uint64.
@@ -252,6 +252,8 @@ func strToMethod(s string) gen.Method {
 		return gen.Marshal
 	case "unmarshal":
 		return gen.Unmarshal
+	case "maxsize":
+		return gen.MaxSize
 	default:
 		return 0
 	}
@@ -407,6 +409,7 @@ func (fs *FileSet) getField(importPrefix string, f *ast.Field) []gen.StructField
 	var extension, flatten bool
 	var allocbound string
 	var allocbounds []string
+	var maxtotalbytes string
 
 	// always flatten embedded structs
 	flatten = true
@@ -422,6 +425,9 @@ func (fs *FileSet) getField(importPrefix string, f *ast.Field) []gen.StructField
 			}
 			if strings.HasPrefix(tag, "allocbound=") {
 				allocbounds = append(allocbounds, strings.Split(tag, "=")[1])
+			}
+			if strings.HasPrefix(tag, "maxtotalbytes=") {
+				maxtotalbytes = strings.Split(tag, "=")[1]
 			}
 		}
 		// ignore "-" fields
@@ -472,6 +478,31 @@ func (fs *FileSet) getField(importPrefix string, f *ast.Field) []gen.StructField
 		}
 		return sf
 	}
+
+	// resolve local package type aliases that referenced in this package structs
+	resolveAlias := func(el gen.Elem) {
+		if a, ok := fs.Aliases[el.TypeName()]; ok {
+			if b, ok := a.(*ast.SelectorExpr); ok {
+				if c, ok := b.X.(*ast.Ident); ok {
+					el.Alias(c.Name + "." + b.Sel.Name)
+				}
+			} else if b, ok := a.(*ast.Ident); ok {
+				el.Alias(b.Name)
+			}
+		}
+	}
+	// resolve field alias type
+	resolveAlias(ex)
+	// resolve field map type that have alias type key or value
+	if m, ok := ex.(*gen.Map); ok {
+		resolveAlias(m.Key)
+		resolveAlias(m.Value)
+	}
+	// resolve field slice type that have alias type element
+	if m, ok := ex.(*gen.Slice); ok {
+		resolveAlias(m.Els)
+	}
+
 	sf[0].FieldElem = ex
 	if sf[0].FieldTag == "" {
 		sf[0].FieldTag = sf[0].FieldName
@@ -480,6 +511,7 @@ func (fs *FileSet) getField(importPrefix string, f *ast.Field) []gen.StructField
 		sf[0].FieldTagParts = []string{sf[0].FieldName}
 	}
 	sf[0].FieldElem.SetAllocBound(allocbound)
+	sf[0].FieldElem.SetMaxTotalBytes(maxtotalbytes)
 
 	// validate extension
 	if extension {
@@ -543,9 +575,9 @@ func (fs *FileSet) getFieldsFromEmbeddedStruct(importPrefix string, f ast.Expr) 
 //
 // so, for a struct like
 //
-//	type A struct {
-//		io.Writer
-//  }
+//		type A struct {
+//			io.Writer
+//	 }
 //
 // we want "Writer"
 func embedded(f ast.Expr) string {


### PR DESCRIPTION
## Summary

This PR adds a new file `maxsize.go` that generates MaxSize functions. These function names are autogenerated instead of being defined as pointer receiver methods like other generated functions in order to not require instantiation when being called and since we are interested in maximum possible size of the message and don't need to introspect a particular example of it. 

- String allocbound enforcement at unmarshalling time was added by @cce 
- New `totalallocbound` annotation was added to indicate that a particular collection won't exceed noted size. This isn't yet enforced during unmarshall although in most cases is already enforced in the code that deals with unmarshalled objects. 
- New allocbound syntax was added for maps where: `allocbound=maxnumelements,keyallocbound,valueallocbound` with the latter two entries being optional which reduces to the old allocbound syntax that only enforced the `maxnumelements` This was added to support plain strings as map keys
- If the generation code hits an element of undefined size it emits a panic in the generated code. 

- [ ] Add totalallocbound enforcements to unmarshalling

## Testing

Tested in go-algorand repo