### PR TITLE
ignore s.Name.Name == "_" in getTypeSpecs

### DIFF
--- a/parse/getast.go
+++ b/parse/getast.go
@@ -349,7 +349,7 @@ func (fs *FileSet) getTypeSpecs(f *ast.File) {
 						*ast.MapType,
 						*ast.Ident:
 
-						if strings.HasPrefix(s.Name.Name, "_Ctype_") {
+						if strings.HasPrefix(s.Name.Name, "_Ctype_") || s.Name.Name == "_" {
 							continue
 						}
 


### PR DESCRIPTION
This ignores the `_`-named cgo.Incomplete type when scanning for types.

Related:
https://github.com/golang/go/commit/846c378b8c0cebd2d8522a5693b45ca95b018a78
https://github.com/golang/go/blob/48f4728211c1c4299728b6b3a04a6ddf997d9ec6/src/runtime/cgo/cgo.go#L37-L40