### PR TITLE
Implement remaining canonicity checks

### DIFF
--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -207,7 +207,12 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 	u.p.printf("\n}")
 
 	u.p.printf("\nfor %s > 0 {", sz)
-	u.p.printf("\n%s--; field, bts, err = msgp.ReadMapKeyZC(bts)", sz)
+	u.p.printf("\n%s--", sz)
+	u.p.printf("\n if validate {")
+	u.p.printf("\nfield, bts, err = msgp.ReadMapKeyZCCanonical(bts)")
+	u.p.printf("\n} else {")
+	u.p.printf("\nfield, bts, err = msgp.ReadMapKeyZC(bts)")
+	u.p.printf("\n}")
 	u.p.wrapErrCheck(u.ctx.ArgsStr())
 	u.p.print("\nswitch string(field) {")
 	for i := range s.Fields {

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -295,7 +295,11 @@ func (u *unmarshalGen) gBase(b *BaseElem) {
 			u.p.printf("\nreturn")
 			u.p.printf("\n}")
 		}
-		u.p.printf("\n%s, bts, err = msgp.ReadStringBytes(bts)", refname)
+		u.p.printf("\nif validate {")
+		u.p.printf("\n%s, bts, err = msgp.ReadStringBytesCanonical(bts)", refname)
+		u.p.printf("\n} else {")
+		u.p.printf("\n %s, bts, err = msgp.ReadStringBytes(bts)", refname)
+		u.p.printf("\n}")
 	case Uint, Uint8, Uint16, Uint32, Uint64, Int, Int8, Int16, Int32, Int64:
 		u.p.printf("\nif validate {")
 		u.p.printf("\n%s, bts, err = msgp.Read%sBytesCanonical(bts)", refname, b.BaseName())

--- a/gen/unmarshal.go
+++ b/gen/unmarshal.go
@@ -175,7 +175,7 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 	u.assignAndCheck(sz, isnil, arrayHeader)
 
 	u.p.print("\nif validate {") // map encoded as array => non canonical
-	u.p.print("\nerr = msgp.ErrNonCanonical{reason: \"map encoded as array\"}")
+	u.p.print("\nerr = msgp.ErrNonCanonical(\"map encoded as array\")")
 	u.p.print("\nreturn")
 	u.p.print("\n}")
 
@@ -220,7 +220,7 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 		}
 		u.p.printf("\ncase \"%s\":", s.Fields[i].FieldTag)
 		u.p.printf("\nif validate && %s && \"%s\" < %s {", lastIsSet, s.Fields[i].FieldTag, last)
-		u.p.print("\nerr = msgp.ErrNonCanonical{reason: \"struct fields out of order\"}")
+		u.p.print("\nerr = msgp.ErrNonCanonical(\"struct fields out of order\")")
 		u.p.printf("\nreturn")
 		u.p.print("\n}")
 		u.ctx.PushString(s.Fields[i].FieldName)
@@ -228,7 +228,7 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 		u.ctx.Pop()
 		if ize := s.Fields[i].FieldElem.IfZeroExpr(); ize != "" && isFieldOmitEmpty(s.Fields[i], s) {
 			u.p.printf("\nif validate && %s {", ize)
-			u.p.printf("\nerr = msgp.ErrNonCanonical{reason: \"zero value for omitempty field\"}")
+			u.p.printf("\nerr = msgp.ErrNonCanonical(\"zero value for omitempty field\")")
 			u.p.printf("\nreturn")
 			u.p.printf("\n}")
 		}
@@ -240,12 +240,6 @@ func (u *unmarshalGen) mapstruct(s *Struct) {
 	u.p.printf("\n%s = true", lastIsSet)
 	u.p.print("\n}") // close for loop
 	u.p.print("\n}") // close else statement for array decode
-	u.p.print("\n if validate {")
-	u.p.print("\n if len(bts) > 0 {")
-	u.p.printf("\n err = msgp.ErrNonCanonical{reason: \"unexpected trailing bytes\"}")
-	u.p.printf("\n return")
-	u.p.print("\n }") // close if len(bts) statement
-	u.p.print("\n }") // close if validate statement
 }
 
 func (u *unmarshalGen) gBase(b *BaseElem) {
@@ -388,11 +382,11 @@ func (u *unmarshalGen) gMap(m *Map) {
 	u.p.printf("\nif validate {")
 	if m.Key.LessFunction() != "" {
 		u.p.printf("\nif %s && %s(%s, %s) {", lastSet, m.Key.LessFunction(), m.Keyidx, last)
-		u.p.printf("\nerr = msgp.ErrNonCanonical{reason: \"map keys out of order\"}")
+		u.p.printf("\nerr = msgp.ErrNonCanonical(\"map keys out of order\")")
 		u.p.printf("\nreturn")
 		u.p.printf("\n}")
 	} else {
-		u.p.printf("\nerr = &msgp.ErrMissingLessFn{}")
+		u.p.printf("\nerr = msgp.ErrMissingLessFn{}")
 		u.p.printf("\nreturn")
 	}
 	u.p.printf("\n}") // close if validate block

--- a/msgp/defs.go
+++ b/msgp/defs.go
@@ -34,6 +34,9 @@ const last5 = 0x1f
 const first3 = 0xe0
 const last7 = 0x7f
 
+const minFixnInt = -32
+const maxFixInt = 127
+
 func isfixint(b byte) bool {
 	return b>>7 == 0
 }

--- a/msgp/defs.go
+++ b/msgp/defs.go
@@ -37,6 +37,8 @@ const last7 = 0x7f
 const minFixnInt = -32
 const maxFixInt = 127
 
+const maxFixStrLen = 31
+
 func isfixint(b byte) bool {
 	return b>>7 == 0
 }

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -344,20 +344,20 @@ func (e *ErrUnsupportedType) withContext(ctx string) error {
 	return &o
 }
 
-// ErrNonCanonical is returned
+// errNonCanonical is returned
 // when unmarshaller detects that
 // the message is not canonically encoded (pre-sorted)
-type ErrNonCanonical struct {
+type errNonCanonical struct {
 	reason string
 }
 
 // Error implements error
-func (e ErrNonCanonical) Error() string {
+func (e errNonCanonical) Error() string {
 	return fmt.Sprintf("msgp: non-canonical encoding: %s", e.reason)
 }
 
 // Resumable returns false for errNonCanonical
-func (e ErrNonCanonical) Resumable() bool { return false }
+func (e errNonCanonical) Resumable() bool { return false }
 
 // ErrNonCanonical is returned
 // when unmarshaller detects that
@@ -365,9 +365,13 @@ func (e ErrNonCanonical) Resumable() bool { return false }
 type ErrMissingLessFn struct{}
 
 // Error implements error
-func (e *ErrMissingLessFn) Error() string {
+func (e ErrMissingLessFn) Error() string {
 	return fmt.Sprintf("msgp: can't validate canonicity: missing LessFn")
 }
 
 // Resumable returns false for errNonCanonical
-func (e *ErrMissingLessFn) Resumable() bool { return false }
+func (e ErrMissingLessFn) Resumable() bool { return false }
+
+func ErrNonCanonical(reason string) error {
+	return errNonCanonical{reason}
+}

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -359,19 +359,44 @@ func (e errNonCanonical) Error() string {
 // Resumable returns false for errNonCanonical
 func (e errNonCanonical) Resumable() bool { return false }
 
-// ErrNonCanonical is returned
+func ErrNonCanonical(reason string) error {
+	return errNonCanonical{reason}
+}
+
+// errMissingLessFn is returned
 // when unmarshaller detects that
-// the message is not canonically encoded (pre-sorted)
-type ErrMissingLessFn struct{}
+// the LessFunc is not provided for the type and the canonicity cannot be validated
+type errMissingLessFn struct {
+	typeName string
+}
 
 // Error implements error
-func (e ErrMissingLessFn) Error() string {
+func (e errMissingLessFn) Error() string {
 	return fmt.Sprintf("msgp: can't validate canonicity: missing LessFn")
 }
 
 // Resumable returns false for errNonCanonical
-func (e ErrMissingLessFn) Resumable() bool { return false }
+func (e errMissingLessFn) Resumable() bool { return false }
 
-func ErrNonCanonical(reason string) error {
-	return errNonCanonical{reason}
+func ErrMissingLessFn(typeName string) error {
+	return errMissingLessFn{typeName}
+}
+
+// errMissingZeroExpr is returned
+// when unmarshaller detects that
+// the message is not canonically encoded (pre-sorted)
+type errMissingZeroExpr struct {
+	typeName string
+}
+
+// Error implements error
+func (e errMissingZeroExpr) Error() string {
+	return fmt.Sprintf("msgp: can't validate canonicity: missing LessFn")
+}
+
+// Resumable returns false for errNonCanonical
+func (e errMissingZeroExpr) Resumable() bool { return false }
+
+func ErrMissingZeroExpr(typeName string) error {
+	return errMissingZeroExpr{typeName}
 }

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -347,15 +347,17 @@ func (e *ErrUnsupportedType) withContext(ctx string) error {
 // ErrNonCanonical is returned
 // when unmarshaller detects that
 // the message is not canonically encoded (pre-sorted)
-type ErrNonCanonical struct{}
+type ErrNonCanonical struct {
+	reason string
+}
 
 // Error implements error
-func (e *ErrNonCanonical) Error() string {
-	return fmt.Sprintf("msgp: non-canonical encoding detected")
+func (e ErrNonCanonical) Error() string {
+	return fmt.Sprintf("msgp: non-canonical encoding: %s", e.reason)
 }
 
 // Resumable returns false for errNonCanonical
-func (e *ErrNonCanonical) Resumable() bool { return false }
+func (e ErrNonCanonical) Resumable() bool { return false }
 
 // ErrNonCanonical is returned
 // when unmarshaller detects that

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -435,11 +435,11 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		}
 		i = int64(getMint8(b))
 		o = b[2:]
-		if (i << 7) == 0 {
-			err = errNonCanonical{reason: "non-minimal encoding length"}
-		}
 		if i > 0 {
 			err = errNonCanonical{reason: "positive value encoded as signed"}
+		}
+		if i >= minFixnInt {
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 	case muint8:
@@ -449,7 +449,7 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		}
 		i = int64(getMuint8(b))
 		o = b[2:]
-		if (i << 7) == 0 {
+		if i <= maxFixInt {
 			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
@@ -461,11 +461,11 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		}
 		i = int64(getMint16(b))
 		o = b[3:]
-		if (i << 8) == 0 {
-			err = errNonCanonical{reason: "non-minimal encoding length"}
-		}
 		if i > 0 {
 			err = errNonCanonical{reason: "positive value encoded as signed"}
+		}
+		if i >= math.MinInt8 {
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
@@ -475,7 +475,7 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 			return
 		}
 		i = int64(getMuint16(b))
-		if (i << 8) == 0 {
+		if i <= math.MaxUint8 {
 			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		o = b[3:]
@@ -488,11 +488,11 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		}
 		i = int64(getMint32(b))
 		o = b[5:]
-		if (i << 16) == 0 {
-			err = errNonCanonical{reason: "non-minimal encoding length"}
-		}
 		if i > 0 {
 			err = errNonCanonical{reason: "positive value encoded as signed"}
+		}
+		if i >= math.MinInt16 {
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
@@ -503,7 +503,7 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		}
 		i = int64(getMuint32(b))
 		o = b[5:]
-		if (i << 16) == 0 {
+		if i <= math.MaxUint16 {
 			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
@@ -515,11 +515,11 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		}
 		i = int64(getMint64(b))
 		o = b[9:]
-		if (i << 32) == 0 {
-			err = errNonCanonical{reason: "non-minimal encoding length"}
-		}
 		if i > 0 {
 			err = errNonCanonical{reason: "positive value encoded as signed"}
+		}
+		if i >= math.MinInt32 {
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
@@ -538,7 +538,7 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		// }
 		i = int64(u)
 		o = b[9:]
-		if (i << 32) == 0 {
+		if i <= math.MaxUint32 {
 			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
@@ -790,7 +790,7 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		}
 		u = uint64(getMuint8(b))
 		o = b[2:]
-		if (u << 7) == 0 {
+		if u <= maxFixInt {
 			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
@@ -806,7 +806,7 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		}
 		u = uint64(getMuint16(b))
 		o = b[3:]
-		if (u << 8) == 0 {
+		if u <= math.MaxUint8 {
 			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
@@ -821,7 +821,7 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		}
 		u = uint64(getMuint32(b))
 		o = b[5:]
-		if (u << 16) == 0 {
+		if u <= math.MaxUint16 {
 			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
@@ -836,7 +836,7 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		}
 		u = getMuint64(b)
 		o = b[9:]
-		if (u << 32) == 0 {
+		if u <= math.MaxUint32 {
 			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return

--- a/msgp/read_bytes.go
+++ b/msgp/read_bytes.go
@@ -436,10 +436,10 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		i = int64(getMint8(b))
 		o = b[2:]
 		if (i << 7) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		if i > 0 {
-			err = ErrNonCanonical{reason: "positive value encoded as signed"}
+			err = errNonCanonical{reason: "positive value encoded as signed"}
 		}
 		return
 	case muint8:
@@ -450,7 +450,7 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		i = int64(getMuint8(b))
 		o = b[2:]
 		if (i << 7) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
@@ -462,10 +462,10 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		i = int64(getMint16(b))
 		o = b[3:]
 		if (i << 8) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		if i > 0 {
-			err = ErrNonCanonical{reason: "positive value encoded as signed"}
+			err = errNonCanonical{reason: "positive value encoded as signed"}
 		}
 		return
 
@@ -476,7 +476,7 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		}
 		i = int64(getMuint16(b))
 		if (i << 8) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		o = b[3:]
 		return
@@ -489,10 +489,10 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		i = int64(getMint32(b))
 		o = b[5:]
 		if (i << 16) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		if i > 0 {
-			err = ErrNonCanonical{reason: "positive value encoded as signed"}
+			err = errNonCanonical{reason: "positive value encoded as signed"}
 		}
 		return
 
@@ -504,7 +504,7 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		i = int64(getMuint32(b))
 		o = b[5:]
 		if (i << 16) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
@@ -516,10 +516,10 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		i = int64(getMint64(b))
 		o = b[9:]
 		if (i << 32) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		if i > 0 {
-			err = ErrNonCanonical{reason: "positive value encoded as signed"}
+			err = errNonCanonical{reason: "positive value encoded as signed"}
 		}
 		return
 
@@ -539,7 +539,7 @@ func ReadInt64BytesCanonical(b []byte) (i int64, o []byte, err error) {
 		i = int64(u)
 		o = b[9:]
 		if (i << 32) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
@@ -781,7 +781,7 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		return
 
 	case mint8:
-		err = ErrNonCanonical{reason: "unsigned value encoded as signed"}
+		err = errNonCanonical{reason: "unsigned value encoded as signed"}
 		return
 	case muint8:
 		if l < 2 {
@@ -791,12 +791,12 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		u = uint64(getMuint8(b))
 		o = b[2:]
 		if (u << 7) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
 	case mint16:
-		err = ErrNonCanonical{reason: "unsigned value encoded as signed"}
+		err = errNonCanonical{reason: "unsigned value encoded as signed"}
 		return
 
 	case muint16:
@@ -807,12 +807,12 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		u = uint64(getMuint16(b))
 		o = b[3:]
 		if (u << 8) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
 	case mint32:
-		err = ErrNonCanonical{reason: "unsigned value encoded as signed"}
+		err = errNonCanonical{reason: "unsigned value encoded as signed"}
 		return
 	case muint32:
 		if l < 5 {
@@ -822,12 +822,12 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		u = uint64(getMuint32(b))
 		o = b[5:]
 		if (u << 16) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
 	case mint64:
-		err = ErrNonCanonical{reason: "unsigned value encoded as signed"}
+		err = errNonCanonical{reason: "unsigned value encoded as signed"}
 		return
 	case muint64:
 		if l < 9 {
@@ -837,7 +837,7 @@ func ReadUint64BytesCanonical(b []byte) (u uint64, o []byte, err error) {
 		u = getMuint64(b)
 		o = b[9:]
 		if (u << 32) == 0 {
-			err = ErrNonCanonical{reason: "non-minimal encoding length"}
+			err = errNonCanonical{reason: "non-minimal encoding length"}
 		}
 		return
 
@@ -1206,12 +1206,12 @@ func readBytesBytesCanonical(b []byte, scratch []byte, zc bool, flattenMap bool)
 	// go-codec compat: decode string encodings into byte arrays
 
 	if isfixstr(lead) {
-		err = ErrNonCanonical{reason: "string encoded bytes"}
+		err = errNonCanonical{reason: "string encoded bytes"}
 		return
 	} else {
 		switch lead {
 		case mstr8, mstr16, mstr32:
-			err = ErrNonCanonical{reason: "string encoded bytes"}
+			err = errNonCanonical{reason: "string encoded bytes"}
 			return
 		case mnil:
 			v = nil
@@ -1225,7 +1225,7 @@ func readBytesBytesCanonical(b []byte, scratch []byte, zc bool, flattenMap bool)
 			}
 			read = int(b[1])
 			if read == 0 {
-				err = ErrNonCanonical{reason: "non-minimal bytes encoding"}
+				err = errNonCanonical{reason: "non-minimal bytes encoding"}
 				return
 			}
 			b = b[2:]
@@ -1237,7 +1237,7 @@ func readBytesBytesCanonical(b []byte, scratch []byte, zc bool, flattenMap bool)
 			}
 			read = int(big.Uint16(b[1:]))
 			if read<<8 == 0 {
-				err = ErrNonCanonical{reason: "non-minimal bytes encoding"}
+				err = errNonCanonical{reason: "non-minimal bytes encoding"}
 				return
 			}
 			b = b[3:]
@@ -1252,7 +1252,7 @@ func readBytesBytesCanonical(b []byte, scratch []byte, zc bool, flattenMap bool)
 				return
 			}
 			if read<<16 == 0 {
-				err = ErrNonCanonical{reason: "non-minimal bytes encoding"}
+				err = errNonCanonical{reason: "non-minimal bytes encoding"}
 				return
 			}
 			b = b[5:]
@@ -1268,7 +1268,7 @@ func readBytesBytesCanonical(b []byte, scratch []byte, zc bool, flattenMap bool)
 				// If that doesn't work, return the original error code.
 				err = badPrefix(BinType, lead)
 			} else {
-				err = ErrNonCanonical{reason: "array encoded bytes"}
+				err = errNonCanonical{reason: "array encoded bytes"}
 			}
 			return
 		}

--- a/msgp/write_bytes.go
+++ b/msgp/write_bytes.go
@@ -86,7 +86,7 @@ func AppendInt64(b []byte, i int64) []byte {
 		return AppendUint64(b, uint64(i))
 	}
 	switch {
-	case i >= -32:
+	case i >= minFixnInt:
 		return append(b, wnfixint(int8(i)))
 	case i >= math.MinInt8:
 		o, n := ensure(b, 2)


### PR DESCRIPTION
## Summary

This PR implements missing canonical checks for Marshall validate defined here:

https://github.com/algorandfoundation/specs/blob/master/dev/crypto.md

Specifically it implements conditions: 2-5 listed here:

1. Maps must omit key-value pairs where the value is a zero-value, unless otherwise specified;
2. Positive integer values must be encoded as "unsigned" in msgpack, regardless of whether the value space is semantically signed or unsigned;
3. Integer values must be represented in the shortest possible encoding;
4. Binary arrays must be represented using the "bin" format family (that is, use the most recent version of msgpack rather than the older msgpack version that had no "bin" family).

## TODO

- [ ] Implement minimal length encoding checking for strings as well

## Testing
Currently, the generated code compiles but isn't yet tested for correctness hence draft status. 
