### PR TITLE
fix dead code appearing after panic

### DIFF
--- a/gen/maxsize.go
+++ b/gen/maxsize.go
@@ -112,7 +112,13 @@ func (s *maxSizeGen) Execute(p Elem) ([]string, error) {
 	s.p.printf("\nfunc  %s (s int) {", getMaxSizeMethod(p.TypeName()))
 	s.state = assignM
 	next(s, p)
-	s.p.nakedReturn()
+	if s.halted {
+		if s.p.ok() {
+			s.p.print("\n}\n")
+		}
+	} else {
+		s.p.nakedReturn()
+	}
 	s.topics.Add(p.TypeName(), getMaxSizeMethod(p.TypeName()))
 	return nil, s.p.err
 }


### PR DESCRIPTION
This fixes Go vet warnings on 1.25 about code appearing after panic() calls.

Diffs of msgp_gen.go in https://github.com/algorand/go-algorand/pull/6468 show the effect.